### PR TITLE
Removing unnecessary css links

### DIFF
--- a/arduino-tutorial-1.html
+++ b/arduino-tutorial-1.html
@@ -10,9 +10,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
     <link rel="stylesheet" href="styles/shCoreDefault.css" />
     <script type="text/javascript" src="scripts/shCore.js"></script>
     <script type="text/javascript" src="scripts/shBrushJava.js"></script>

--- a/arduino-tutorial-index.html
+++ b/arduino-tutorial-index.html
@@ -10,9 +10,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body>

--- a/browse.html
+++ b/browse.html
@@ -16,9 +16,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body class="landing">

--- a/events.html
+++ b/events.html
@@ -18,10 +18,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -17,9 +17,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body class="landing">

--- a/minecraft-admin.html
+++ b/minecraft-admin.html
@@ -18,9 +18,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body>

--- a/minecraft.html
+++ b/minecraft.html
@@ -17,9 +17,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body>

--- a/minecraftClientTutorial.html
+++ b/minecraftClientTutorial.html
@@ -17,10 +17,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body>

--- a/projects.html
+++ b/projects.html
@@ -16,9 +16,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body>

--- a/tutorial.html
+++ b/tutorial.html
@@ -18,9 +18,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body>

--- a/videos.html
+++ b/videos.html
@@ -17,9 +17,6 @@
     <script src="js/skel.min.js"></script>
     <script src="js/skel-layers.min.js"></script>
     <script src="js/init.js"></script>
-    <link rel="stylesheet" href="css/skel.css" />
-    <link rel="stylesheet" href="css/browse_style.css" />
-    <link rel="stylesheet" href="css/style-xlarge.css" />
 </head>
 
 <body class="landing">


### PR DESCRIPTION
skel takes care of loading css files (and much more) through init.js.
As such, all of these css requests are unnecessary and slow down the server.